### PR TITLE
feat: :sparkles: Implement Tool domain model, repository, and persist…

### DIFF
--- a/src/main/java/com/rentaherramientas/tolly/application/mapper/ToolMapper.java
+++ b/src/main/java/com/rentaherramientas/tolly/application/mapper/ToolMapper.java
@@ -1,0 +1,19 @@
+package com.rentaherramientas.tolly.application.mapper;
+
+import com.rentaherramientas.tolly.domain.model.enums.ToolStatus;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface ToolMapper {
+
+    // Convierte ToolStatus a String (almacenado en la base de datos)
+    default String toolStatusToString(ToolStatus status) {
+        return status != null ? status.name() : null;  // Usa el nombre del enum como String
+    }
+
+    // Convierte String (de la base de datos) a ToolStatus (enum)
+    default ToolStatus stringToToolStatus(String status) {
+        return status != null ? ToolStatus.valueOf(status) : null;
+    }
+}
+

--- a/src/main/java/com/rentaherramientas/tolly/domain/model/Tool.java
+++ b/src/main/java/com/rentaherramientas/tolly/domain/model/Tool.java
@@ -1,0 +1,72 @@
+package com.rentaherramientas.tolly.domain.model;
+import com.rentaherramientas.tolly.domain.model.enums.ToolStatus;
+
+public class Tool {
+    private Long id;
+    private Long supplierId;
+    private Long categoryId;
+    private String name;
+    private String description;
+    private Double dailyCost;
+    private ToolStatus status;
+
+    public Tool() {
+}
+
+    public Tool(Long id,
+                Long supplierId,
+                Long categoryId,
+                String name,
+                String description,
+                Double dailyCost,
+                ToolStatus status) {
+
+        if (supplierId == null || supplierId <= 0) {
+            throw new IllegalArgumentException("El ID del proveedor no puede ser nulo o menor o igual a cero");
+        }
+        if (categoryId == null || categoryId <= 0) {
+            throw new IllegalArgumentException("El ID de la categoría no puede ser nulo o menor o igual a cero");
+        }
+        if (name == null || name.isBlank()) {
+            throw new IllegalArgumentException("El nombre de la herramienta no puede ser nulo o vacío");
+        }
+        if (description == null || description.isBlank()) {
+            throw new IllegalArgumentException("La descripción de la herramienta no puede ser nula o vacía");
+        }
+        if (dailyCost == null || dailyCost < 0) {
+            throw new IllegalArgumentException("El costo diario no puede ser nulo o negativo");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("El estado de la herramienta no puede ser nulo o vacío");
+        }
+
+        this.id = id;
+        this.supplierId = supplierId;
+        this.categoryId = categoryId;
+        this.name = name;
+        this.description = description;
+        this.dailyCost = dailyCost;
+        this.status = status;
+    }
+
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+
+    public Long getSupplierId() {return supplierId;}
+    public void setSupplierId(Long supplierId) {this.supplierId = supplierId;}
+
+    public Long getCategoryId() {return categoryId;}
+    public void setCategoryId(Long categoryId) {this.categoryId = categoryId;}
+
+    public String getName() {return name;}
+    public void setName(String name) {this.name = name;}
+
+    public String getDescription() {return description;}
+    public void setDescription(String description) {this.description = description;}
+
+    public Double getDailyCost() {return dailyCost;}
+    public void setDailyCost(Double dailyCost) {this.dailyCost = dailyCost;}
+
+    public ToolStatus getStatus() {return status;}
+    public void setStatus(ToolStatus status) {this.status = status;}
+}

--- a/src/main/java/com/rentaherramientas/tolly/domain/model/enums/ToolStatus.java
+++ b/src/main/java/com/rentaherramientas/tolly/domain/model/enums/ToolStatus.java
@@ -1,0 +1,7 @@
+package com.rentaherramientas.tolly.domain.model.enums;
+
+public enum ToolStatus {
+    AVAIBLE,
+    IN_REPAIR,
+    RENTED;
+}

--- a/src/main/java/com/rentaherramientas/tolly/domain/ports/ToolRepository.java
+++ b/src/main/java/com/rentaherramientas/tolly/domain/ports/ToolRepository.java
@@ -1,0 +1,18 @@
+package com.rentaherramientas.tolly.domain.ports;
+import java.util.Optional;
+import java.util.List;
+
+import com.rentaherramientas.tolly.domain.model.Tool;
+
+public interface ToolRepository {
+    List<Tool> findAll();
+
+    Optional<Tool> findById(Long id);
+
+    Optional<Tool> update(Long id, Tool tool);
+
+    Tool save(Tool tool);
+    
+    Optional<Tool> deleteById(Long id);
+
+}

--- a/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/adapters/out/persistence/ToolRepositoryAdapter.java
+++ b/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/adapters/out/persistence/ToolRepositoryAdapter.java
@@ -1,0 +1,70 @@
+package com.rentaherramientas.tolly.infrastructure.persistence.adapters.out.persistence;
+import java.util.List;
+import java.util.Optional;
+
+import com.rentaherramientas.tolly.domain.model.Tool;
+import com.rentaherramientas.tolly.domain.model.enums.ToolStatus;
+import com.rentaherramientas.tolly.domain.ports.ToolRepository;
+import com.rentaherramientas.tolly.infrastructure.persistence.entity.ToolEntity;
+import com.rentaherramientas.tolly.infrastructure.persistence.repository.ToolJpaRepository;
+import com.rentaherramientas.tolly.application.mapper.ToolMapper;
+
+public class ToolRepositoryAdapter implements ToolRepository {
+    private final ToolJpaRepository toolJpaRepository;
+    public ToolRepositoryAdapter(ToolJpaRepository toolJpaRepository) {
+        this.toolJpaRepository = toolJpaRepository;
+    }
+    @Override
+    public List<Tool> findAll() {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'findAll'");
+    }
+    @Override
+    public Optional<Tool> findById(Long id) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'findById'");
+    }
+    @Override
+    public Optional<Tool> update(Long id, Tool tool) {
+        // TODO Auto-generated method stub
+        throw new UnsupportedOperationException("Unimplemented method 'update'");
+    }
+    @Override
+    public Tool save(Tool tool) {
+    ToolEntity toolEntity = ToolRepositoryAdapter.toEntity(tool);
+    ToolEntity savedToolEntity = toolJpaRepository.save(toolEntity);
+    return ToolRepositoryAdapter.toDomain(savedToolEntity);
+}
+    @Override
+    public Optional<Tool> deleteById(Long id) {
+        var existing = toolJpaRepository.findById(id);
+        if (existing.isEmpty()) return Optional.empty();
+        toolJpaRepository.deleteById(id);
+        return existing.map(ToolRepositoryAdapter::toDomain);
+    }
+
+    public static Tool toDomain(ToolEntity toolEntity) {
+        Tool tool = new Tool();
+        tool.setId(toolEntity.getId());
+        tool.setSupplierId(toolEntity.getSupplierId());
+        tool.setCategoryId(toolEntity.getCategoryId());
+        tool.setName(toolEntity.getName());
+        tool.setDescription(toolEntity.getDescription());
+        tool.setDailyCost(toolEntity.getDailyCost());
+        tool.setStatus(toolEntity.getStatus()); 
+        return tool;
+    }
+
+    // Convertir Tool (dominio) a ToolEntity
+    public static ToolEntity toEntity(Tool tool) {
+        ToolEntity toolEntity = new ToolEntity();
+        toolEntity.setId(tool.getId());
+        toolEntity.setSupplierId(tool.getSupplierId());
+        toolEntity.setCategoryId(tool.getCategoryId());
+        toolEntity.setName(tool.getName());
+        toolEntity.setDescription(tool.getDescription());
+        toolEntity.setDailyCost(tool.getDailyCost());
+        toolEntity.setStatus(tool.getStatus());
+        return toolEntity;
+    }
+}

--- a/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/entity/ToolEntity.java
+++ b/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/entity/ToolEntity.java
@@ -1,0 +1,61 @@
+package com.rentaherramientas.tolly.infrastructure.persistence.entity;
+import com.rentaherramientas.tolly.domain.model.enums.ToolStatus;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "tools")
+public class ToolEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "id_supplier", nullable = false)
+    private Long supplierId;
+
+    @Column(name = "id_category", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "description", nullable = true)
+    private String description;
+
+    @Column(name = "daily_cost", nullable = false)
+    private Double dailyCost;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ToolStatus status;
+
+    public ToolEntity() {}
+
+    public Long getId() {return id;}
+    public void setId(Long id) {this.id = id;}
+
+    public Long getSupplierId() {return supplierId;}
+    public void setSupplierId(Long supplierId) {this.supplierId = supplierId;}
+
+    public Long getCategoryId() {return categoryId;}
+    public void setCategoryId(Long categoryId) {this.categoryId = categoryId;}
+
+    public String getName() {return name;}
+    public void setName(String name) {this.name = name;}
+
+    public String getDescription() {return description;}
+    public void setDescription(String description) {this.description = description;}
+
+    public Double getDailyCost() {return dailyCost;}
+    public void setDailyCost(Double dailyCost) {this.dailyCost = dailyCost;}
+
+    public ToolStatus getStatus() {return status;}
+    public void setStatus(ToolStatus status) {this.status = status;}
+}

--- a/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/repository/ToolJpaRepository.java
+++ b/src/main/java/com/rentaherramientas/tolly/infrastructure/persistence/repository/ToolJpaRepository.java
@@ -1,0 +1,9 @@
+package com.rentaherramientas.tolly.infrastructure.persistence.repository;
+
+import com.rentaherramientas.tolly.infrastructure.persistence.entity.ToolEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ToolJpaRepository extends JpaRepository<ToolEntity, Long> {
+}


### PR DESCRIPTION
## Flujo de Creación

1. **Definición del Modelo**: 
   La clase `Tool` contiene los atributos y validaciones para la herramienta en el dominio.

2. **Definición del Enum `ToolStatus`**: 
   Establece los diferentes estados posibles para una herramienta.

3. **Creación del Puerto `ToolRepository`**: 
   Define las operaciones CRUD básicas que deben ser implementadas.

4. **Creación de la Entidad `ToolEntity`**: 
   Mapea la herramienta a la base de datos con JPA.

5. **Creación del Repositorio JPA `ToolJpaRepository`**: 
   Extiende `JpaRepository` para gestionar las operaciones de persistencia.

6. **Creación del Adaptador de Persistencia `ToolRepositoryAdapter`**: 
   Implementa el puerto `ToolRepository` y utiliza el repositorio JPA para interactuar con la base de datos.

7. **Creación del Mapper `ToolMapper`**: 
   Separa la lógica de conversión entre el modelo de dominio y la entidad JPA.